### PR TITLE
(FIX) Eliminate creation of data on startup

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -19,15 +19,6 @@ spec:
       annotations:
         checksum/config: {{ include (print .Template.BasePath "/config-lnd.yaml") . | sha256sum }}
     spec:
-      {{- if not .Values.lnd.keystoreSecret }}
-      initContainers:
-        - name: lnd-init
-          image: busybox
-          command: ["mkdir", "-p", "/root/.lnd/data/certs"]
-          volumeMounts:
-          - name: data
-            mountPath: /root/.lnd/data
-      {{- end }}
       containers:
         - name: lnd
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
🐛  Newer version of lnd try to create `.lnd` folders path to `data` on startup. In our case `/data` exists on startup as read-only